### PR TITLE
Use extension crate instead of trussed-staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Use `trussed-chunked` instead of `trussed-staging`, see
+  [trussed-staging#19][].
+
+[trussed-staging#19]: https://github.com/trussed-dev/trussed-staging/pull/19
+
 ## [v0.3.4][] (2024-01-02)
 
 - Fix error when changing the PUK ([#40][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+-
+
+## [v0.4.0][] (2024-03-15)
+
+[v0.4.0]: https://github.com/trussed-dev/piv-authenticator/releases/tag/v0.4.0
+
 - Use `trussed-chunked` instead of `trussed-staging`, see
   [trussed-staging#19][].
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piv-authenticator"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Nicolas Stalder <n@stalder.io>", "Nitrokey GmbH"]
 edition = "2021"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ vpicc = { version = "0.1.0", optional = true }
 log = "0.4"
 heapless-bytes = "0.3.0"
 subtle = { version = "2", default-features = false }
+trussed-chunked = "0.1.0"
 trussed-rsa-alloc = { version = "0.1.0", features = ["raw"], optional = true }
-trussed-staging = { version = "0.1.0", features = ["chunked", "encrypted-chunked"]}
 
 [dev-dependencies]
 littlefs2 = "0.3.2"
@@ -77,8 +77,8 @@ log-error = []
 [patch.crates-io]
 trussed = { git = "https://github.com/nitrokey/trussed" , tag = "v0.1.0-nitrokey.11" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth.git", tag = "v0.2.2"}
+trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", tag = "v0.1.0"}
-trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging", tag = "v0.1.0" }
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.2-nitrokey.2" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.1" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub mod state;
 mod tlv;
 
 pub use piv_types::{AsymmetricAlgorithms, Pin, Puk};
-use trussed_staging::streaming::ChunkedClient;
+use trussed_chunked::ChunkedClient;
 
 #[cfg(feature = "virt")]
 pub mod virt;

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,7 +11,7 @@ use trussed::{
     syscall, try_syscall,
     types::{KeyId, KeySerialization, Location, Mechanism, PathBuf, StorageAttributes},
 };
-use trussed_staging::streaming::utils;
+use trussed_chunked::utils;
 
 use crate::piv_types::CardHolderUniqueIdentifier;
 use crate::reply::Reply;


### PR DESCRIPTION
This patch adapts to the extraction of extension crates from trussed-staging, see:
        trussed-dev/trussed-staging#19