### PR TITLE
Remove unused ids

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use flexiber::EncodableHeapless;
 use heapless_bytes::Bytes;
 use iso7816::{Data, Status};
 use trussed_auth::AuthClient;
-use trussed_core::mechanisms::{Ed255, Tdes};
+use trussed_core::mechanisms::Tdes;
 use trussed_core::types::{KeySerialization, Location, Mechanism, PathBuf, StorageAttributes};
 use trussed_core::{syscall, try_syscall, CryptoClient, FilesystemClient};
 
@@ -143,9 +143,7 @@ where
         let application_property_template = piv_types::ApplicationPropertyTemplate::default()
             .with_application_label(self.options.label)
             .with_application_url(self.options.url)
-            .with_supported_cryptographic_algorithms(&[
-                Tdes, Aes256, P256, Ed25519, X25519, Rsa2048,
-            ]);
+            .with_supported_cryptographic_algorithms(&[Tdes, Aes256, P256, Rsa2048]);
 
         application_property_template
             .encode_to_heapless_vec(*reply)
@@ -1121,7 +1119,6 @@ pub trait Client:
     + FilesystemClient
     + AuthClient
     + ChunkedClient
-    + Ed255
     + Tdes
     + WrapKeyToFileClient
     + HpkeClient
@@ -1132,7 +1129,6 @@ impl<
             + FilesystemClient
             + AuthClient
             + ChunkedClient
-            + Ed255
             + Tdes
             + WrapKeyToFileClient
             + HpkeClient,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,9 @@ where
         let application_property_template = piv_types::ApplicationPropertyTemplate::default()
             .with_application_label(self.options.label)
             .with_application_url(self.options.url)
-            .with_supported_cryptographic_algorithms(&[Tdes, Aes256, P256, Rsa2048]);
+            .with_supported_cryptographic_algorithms(&[
+                Tdes, Aes256, P256, Rsa2048, Rsa3072, Rsa4096, P384,
+            ]);
 
         application_property_template
             .encode_to_heapless_vec(*reply)

--- a/src/piv_types.rs
+++ b/src/piv_types.rs
@@ -108,7 +108,7 @@ enum_u8! {
     // references Opacity ZKM.
     pub enum Algorithms {
         Tdes = 0x3,
-        Rsa1024 = 0x6,
+        // Rsa1024 = 0x6,
         Rsa2048 = 0x7,
         Aes128 = 0x8,
         Aes192 = 0xA,
@@ -121,20 +121,20 @@ enum_u8! {
         // Ed255_prev = 0x22,
 
         // https://globalplatform.org/wp-content/uploads/2014/03/GPC_ISO_Framework_v1.0.pdf#page=15
-        P521 = 0x15,
+        // P521 = 0x15,
         // non-standard!
         Rsa4096 = 0x16,
-        Ed25519 = 0xE2,
-        X25519 = 0xE3,
-        Ed448 = 0xE4,
-        X448 = 0xE5,
+        // Ed25519 = 0xE2,
+        // X25519 = 0xE3,
+        // Ed448 = 0xE4,
+        // X448 = 0xE5,
 
         // non-standard! picked by Alex, but maybe due for removal
-        P256Sha1 = 0xF0,
-        P256Sha256 = 0xF1,
-        P384Sha1 = 0xF2,
-        P384Sha256 = 0xF3,
-        P384Sha384 = 0xF4,
+        // P256Sha1 = 0xF0,
+        // P256Sha256 = 0xF1,
+        // P384Sha1 = 0xF2,
+        // P384Sha256 = 0xF3,
+        // P384Sha384 = 0xF4,
     }
 }
 


### PR DESCRIPTION
This fixes some confusion I saw regarding non-standard IDs that were actually not used.

This also fixes the `supported_cryptographic_algorithms` list in the `ApplicationPropertyTemplate` Data Object.